### PR TITLE
ci(npm): fix publishing to gh npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,15 +146,6 @@ jobs:
           registry-url: ${{ matrix.registry-url }}
           scope: '@lizardbyte'
 
-      - name: Update package.json
-        run: npm version ${{ needs.setup_release.outputs.release_version }} --no-git-tag-version
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build
-        run: npm run build
-
       - name: Set token
         id: token
         run: |
@@ -165,7 +156,18 @@ jobs:
             echo "NODE_AUTH_TOKEN=${{ secrets.NPM_TOKEN }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Publish
-        run: npm publish ${{ matrix.extra-args }}
+      - name: Update package.json
+        run: npm version ${{ needs.setup_release.outputs.release_version }} --no-git-tag-version
+
+      - name: Install dependencies
         env:
           NODE_AUTH_TOKEN: ${{ steps.token.outputs.NODE_AUTH_TOKEN }}
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ steps.token.outputs.NODE_AUTH_TOKEN }}
+        run: npm publish ${{ matrix.extra-args }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Installing dependencies fails because it's expecting to find shared-web in the github registry.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
